### PR TITLE
Keep GitHub Actions up to date with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#about-the-dependabotyml-file
+version: 2
+
+updates:
+  # Configure check for outdated GitHub Actions actions in workflows.
+  # See: https://docs.github.com/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+  - package-ecosystem: github-actions
+    directory: / # Check the repository's workflows under /.github/workflows/
+    schedule:
+      interval: daily

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
     - uses: actions/setup-python@v1
     - run: pip install codespell
     - uses: ./
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
     - uses: actions/setup-python@v1
     - run: pip install git+https://github.com/codespell-project/codespell.git
     - uses: ./


### PR DESCRIPTION
Reference major versions of versioned actions, as suggested in:
https://docs.github.com/en/actions/creating-actions/about-custom-actions#good-practices-for-release-management

See https://github.com/codespell-project/codespell/pull/2578#issuecomment-1300059727.

Let's see if the [actions/setup-python](https://github.com/actions/setup-python) triggers an update from `@v1` to `@v4` :smiley: